### PR TITLE
Use SPDX identifier to explicit the license

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ class BisonConan(ConanFile):
     url = "https://github.com/bincrafters/conan-bison"
     homepage = "https://www.gnu.org/software/bison/"
     description = "Bison is a general-purpose parser generator"
-    license = "https://git.savannah.gnu.org/cgit/bison.git/tree/COPYING"
+    license = "GPL-3.0-or-later"
     authors = "Bincrafters <bincrafters@gmail.com>"
     exports = ["LICENSE.md"]
     exports_sources = ["secure_snprintf.patch"]


### PR DESCRIPTION
The COPYING file doesn't contain all the details needed to determine the
exact license. Those are in the README, which adds the "or later"
clause. SPDX is meant to easily communicate about the license, and avoid
ambiguities.

More at https://spdx.org/